### PR TITLE
View/header

### DIFF
--- a/src/main/resources/static/css/color.css
+++ b/src/main/resources/static/css/color.css
@@ -166,3 +166,20 @@
 	--bs-btn-disabled-bg: #AE93FF !important; /* 비활성화 시 배경색: 밝은 보라 */
 	--bs-btn-disabled-border-color: #AE93FF !important; /* 비활성화 시 테두리색: 밝은 보라 */
 }
+
+.btn-outline-primary {
+  --bs-btn-color: #65DFAD !important;
+  --bs-btn-border-color: #65DFAD !important;
+  --bs-btn-hover-color: #fff !important;
+  --bs-btn-hover-bg: #65DFAD !important;
+  --bs-btn-hover-border-color: #65DFAD !important;
+  --bs-btn-focus-shadow-rgb: 101, 223, 173 !important;
+  --bs-btn-active-color: #fff !important;
+  --bs-btn-active-bg: #65DFAD !important;
+  --bs-btn-active-border-color: #65DFAD !important;
+  --bs-btn-active-shadow: inset 0 3px 5px rgba(0, 0, 0, 0.125) !important;
+  --bs-btn-disabled-color: #65DFAD !important;
+  --bs-btn-disabled-bg: transparent !important;
+  --bs-btn-disabled-border-color: #65DFAD !important;
+  --bs-gradient: none !important;
+}

--- a/src/main/resources/static/css/main.css
+++ b/src/main/resources/static/css/main.css
@@ -220,3 +220,7 @@ body {
 .scrollbar-width-none {
   scrollbar-width: none;
 }
+
+.btn-no-arrow.dropdown-toggle::after {
+  display: none !important;
+}

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -10,33 +10,26 @@
 		</button>
 
 		<div class="collapse navbar-collapse" id="navbarNav">
-			<ul class="navbar-nav me-auto">
-				<li class="nav-item"><a class="nav-link active" href="/">홈</a></li>
-				<li class="nav-item"><a class="nav-link" href="/board/list">게시판 목록</a></li>
+			<ul class="navbar-nav me-auto gap-2">
+				<li class="nav-item">
+					<th:block th:replace="~{ fragments/header/subscribe }"/>
+				</li>
+				<li class="nav-item">
+					<th:block th:replace="~{ fragments/header/topten }"/>
+				</li>
+				<li class="nav-item">
+					<th:block th:replace="~{ fragments/header/search }"/>
+				</li>
 			</ul>
 
-			<div class="navbar-nav">
-				<div class="nav-item dropdown">
-					<a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown">
-						<i class="bi bi-person-circle"></i> 사용자명 (1,250P)
-					</a>
-					<ul class="dropdown-menu dropdown-menu-end">
-						<li><a class="dropdown-item" href="/board/create">
-								<i class="bi bi-plus-circle"></i> 게시판 개설하기
-							</a></li>
-						<li>
-							<hr class="dropdown-divider">
-						</li>
-						<li><a class="dropdown-item" href="/user/profile">내 정보</a></li>
-						<li><a class="dropdown-item" href="/user/point">포인트 내역</a></li>
-						<li><a class="dropdown-item" href="/user/scrap">스크랩</a></li>
-						<li>
-							<hr class="dropdown-divider">
-						</li>
-						<li><a class="dropdown-item" href="/user/logout">로그아웃</a></li>
-					</ul>
-				</div>
-			</div>
+			<ul class="navbar-nav gap-2">
+				<li class="nav-item">
+					<th:block th:replace="~{ fragments/header/notification }"/>
+				</li>
+				<li class="nav-item">
+					<th:block th:replace="~{ fragments/header/login }"/>
+				</li>
+			</ul>
 		</div>
 	</div>
 </header>

--- a/src/main/resources/templates/fragments/header/login.html
+++ b/src/main/resources/templates/fragments/header/login.html
@@ -1,0 +1,41 @@
+<!-- login not yet -->
+<a th:if="${ false }" href="/login" class="btn btn-outline-primary rounded-circle">
+	<i class="bi bi-person-fill"></i>
+</a>
+
+<!-- logined -->
+<div th:if="${ true }" class="dropdown">
+	<button class="btn btn-outline-primary dropdown-toggle rounded-circle btn-no-arrow" data-bs-toggle="dropdown">
+		<i class="bi bi-person-fill"></i>
+	</button>
+	<ul class="dropdown-menu dropdown-menu-end dropdown-menu-start">
+		<li class="dropdown-header">
+			아카기지배
+		</li>
+		<li class="dropdown-item">
+			1,557 P
+		</li>
+		<li class="dropdown-divider">
+			
+		</li>
+		<li>
+			<a href="" class="dropdown-item">내 정보</a>
+		</li>
+		<li>
+			<a href="/logout" class="dropdown-item">로그아웃</a>
+		</li>
+		<li>
+			<a href="/logout" class="dropdown-item">게시판 생성</a>
+		</li>
+		<li>
+			<a href="/logout" class="dropdown-item">스크랩 목록</a>
+		</li>
+		<li>
+			<a href="/logout" class="dropdown-item">이모티콘</a>
+		</li>
+		<li>
+			<a href="/logout" class="dropdown-item">비밀번호 변경</a>
+		</li>
+		</li>
+	</ul>
+</div>

--- a/src/main/resources/templates/fragments/header/notification.html
+++ b/src/main/resources/templates/fragments/header/notification.html
@@ -1,0 +1,14 @@
+<div class="dropdown">
+	<button class="btn btn-outline-primary rounded-circle dropdown-toggle btn-no-arrow" data-bs-toggle="dropdown">
+		<i class="bi bi-bell-fill"></i>
+	</button>
+	<ul class="dropdown-menu dropdown-menu-end dropdown-menu-start">
+		<li>
+			<h5 class="dropdown-item">주요 알림!!</h5>
+		</li>
+		<li class="dropdown-divider"></li>
+		<li th:each="item : ${ {'게시글에 좋아요~','댓글 달렸습니다.','게시글 신고됨!!!'} }">
+			<a href="" class="dropdown-item" th:text="${ item }"></a>
+		</li>
+	</ul>
+</div>

--- a/src/main/resources/templates/fragments/header/search.html
+++ b/src/main/resources/templates/fragments/header/search.html
@@ -1,0 +1,8 @@
+<form th:action="@{/board/list}" method="get">
+	<div class="input-group">
+		<span class="input-group-text">
+			<i class="bi bi-search"></i>
+		</span>
+		<input type="text" name="keyword" class="form-control" placeholder="검색">
+	</div>
+</form>

--- a/src/main/resources/templates/fragments/header/subscribe.html
+++ b/src/main/resources/templates/fragments/header/subscribe.html
@@ -1,0 +1,13 @@
+<div class="dropdown">
+	<button class="btn btn-ghost dropdown-toggle" data-bs-toggle="dropdown">구독게시판</button>
+	<ul class="dropdown-menu">
+		<li th:if="${ false }">
+			<a class="dropdown-item">
+				구독한 게시판이 없습니다.
+			</a>
+		</li>
+		<li th:each="item : ${ {'방도리','걸방구','마이고아'} }">
+			<a href="" class="dropdown-item" th:text="${ item }"></a>
+		</li>
+	</ul>
+</div>

--- a/src/main/resources/templates/fragments/header/topten.html
+++ b/src/main/resources/templates/fragments/header/topten.html
@@ -1,0 +1,8 @@
+<div class="dropdown">
+	<button class="btn btn-ghost dropdown-toggle" data-bs-toggle="dropdown">주요게시판</button>
+	<ul class="dropdown-menu">
+		<li th:each="item, stat : ${ {'방도리','걸방구','마이고아'} }">
+			<a href="" class="dropdown-item" th:text="${ stat.index + 1 } + '. ' + ${ item }"></a>
+		</li>
+	</ul>
+</div>


### PR DESCRIPTION
# header
헤더 브랜치에서 header.html 에 대해 설계서 요구사항에 맞게 변경하였습니다.   
nav > item(s) 구조에서 item 을 각 요소마다 fragment로 분리하였습니다.
분리한 요소는 5개 이며 아래는 해당 fragment 요소 및 설명입니다.

- topten: 상위게시판 10개를 보여주는 드롭다운 요소 입니다.
- subscribe: 구독한 게시판 목록을 보여주는 드롭다운 입니다. 없을 경우 "구독한 게시판이 없습니다" 요소 출력
- search: 검색 요소입니다. get 방식으로 action은 /board/list 입니다. 
- login: 유저아이콘 버튼 요소입니다. 미 로그인 시 /login으로 보내집니다.(TODO: 수정) 로그인 시 설계서에서 설명한 드롭다운이 표시됩니다.
- notification: 알림 리스트 드롭다운 요소 입니다.